### PR TITLE
add library & variable group permissions

### DIFF
--- a/azuredevops/internal/acceptancetests/resource_library_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_library_permissions_test.go
@@ -1,0 +1,134 @@
+//go:build (all || permissions || resource_library_permissions) && (!exclude_permissions || !exclude_resource_library_permissions)
+// +build all permissions resource_library_permissions
+// +build !exclude_permissions !exclude_resource_library_permissions
+
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/datahelper"
+)
+
+func hclLibraryPermissions(projectName string, permissions map[string]string) string {
+	LibraryPermissions := datahelper.JoinMap(permissions, "=", "\n")
+
+	return fmt.Sprintf(`
+%s
+data "azuredevops_group" "tf-project-readers" {
+	project_id = azuredevops_project.project.id
+	name       = "Readers"
+}
+
+resource "azuredevops_library_permissions" "permissions" {
+	project_id  = azuredevops_project.project.id
+	principal   = data.azuredevops_group.tf-project-readers.id
+	permissions = {
+		%s
+	}
+}
+
+`,
+		testutils.HclProjectResource(projectName),
+		LibraryPermissions,
+	)
+}
+
+func TestAccLibraryPermissions_SetPermissions(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	config := hclLibraryPermissions(projectName, map[string]string{
+		"View":        "allow",
+		"Administer":  "allow",
+		"Create":      "allow",
+		"ViewSecrets": "notset",
+		"Use":         "allow",
+		"Owner":       "allow",
+	})
+	tfNode := "azuredevops_library_permissions.permissions"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckProjectDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckProjectExists(projectName),
+					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfNode, "principal"),
+					resource.TestCheckNoResourceAttr(tfNode, "serviceendpoint_id"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.%", "6"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.View", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Administer", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Create", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.ViewSecrets", "notset"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Use", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Owner", "allow"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLibraryPermissions_UpdatePermissions(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	config1 := hclLibraryPermissions(projectName, map[string]string{
+		"View":        "allow",
+		"Administer":  "allow",
+		"Create":      "allow",
+		"ViewSecrets": "notset",
+		"Use":         "allow",
+		"Owner":       "allow",
+	})
+	config2 := hclLibraryPermissions(projectName, map[string]string{
+		"View":        "allow",
+		"Administer":  "notset",
+		"Create":      "notset",
+		"ViewSecrets": "notset",
+		"Use":         "notset",
+		"Owner":       "notset",
+	})
+	tfNode := "azuredevops_library_permissions.permissions"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckProjectDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: config1,
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckProjectExists(projectName),
+					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfNode, "principal"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.%", "6"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.View", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Administer", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Create", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.ViewSecrets", "notset"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Use", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Owner", "allow"),
+				),
+			},
+			{
+				Config: config2,
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckProjectExists(projectName),
+					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfNode, "principal"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.%", "6"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.View", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Administer", "notset"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Create", "notset"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.ViewSecrets", "notset"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Use", "notset"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Owner", "notset"),
+				),
+			},
+		},
+	})
+}

--- a/azuredevops/internal/acceptancetests/resource_variable_group_permissions_test.go
+++ b/azuredevops/internal/acceptancetests/resource_variable_group_permissions_test.go
@@ -1,0 +1,153 @@
+//go:build (all || permissions || resource_variable_group_permissions) && (!exclude_permissions || !exclude_resource_variable_group_permissions)
+// +build all permissions resource_variable_group_permissions
+// +build !exclude_permissions !exclude_resource_variable_group_permissions
+
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/acceptancetests/testutils"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/datahelper"
+)
+
+func hclVariableGroupPermissions(projectName string, variableGroupName string, permissions map[string]string) string {
+	variableGroupPermissions := datahelper.JoinMap(permissions, "=", "\n")
+
+	return fmt.Sprintf(`
+%s
+
+resource "azuredevops_variable_group" "example" {
+	project_id   = azuredevops_project.project.id
+	name         = "%s"
+	description  = "Test Description"
+	allow_access = true
+
+	variable {
+	  name  = "key1"
+	  value = "val1"
+	}
+  }
+
+data "azuredevops_group" "tf-project-readers" {
+	project_id = azuredevops_project.project.id
+	name       = "Readers"
+}
+
+resource "azuredevops_variable_group_permissions" "permissions" {
+	project_id  = azuredevops_project.project.id
+	variable_group_id = azuredevops_variable_group.example.id
+	principal   = data.azuredevops_group.tf-project-readers.id
+	permissions = {
+		%s
+	}
+}
+
+`,
+		testutils.HclProjectResource(projectName),
+		variableGroupName,
+		variableGroupPermissions,
+	)
+}
+
+func TestAccVariableGroupPermissions_SetPermissions(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	variableGroupName := testutils.GenerateResourceName()
+	config := hclVariableGroupPermissions(projectName, variableGroupName, map[string]string{
+		"View":        "allow",
+		"Administer":  "allow",
+		"Create":      "allow",
+		"ViewSecrets": "notset",
+		"Use":         "allow",
+		"Owner":       "allow",
+	})
+	tfNode := "azuredevops_variable_group_permissions.permissions"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckProjectDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckProjectExists(projectName),
+					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfNode, "principal"),
+					resource.TestCheckResourceAttrSet(tfNode, "variable_group_id"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.%", "6"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.View", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Administer", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Create", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.ViewSecrets", "notset"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Use", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Owner", "allow"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVariableGroupPermissions_UpdatePermissions(t *testing.T) {
+	projectName := testutils.GenerateResourceName()
+	variableGroupName := testutils.GenerateResourceName()
+	config1 := hclVariableGroupPermissions(projectName, variableGroupName, map[string]string{
+		"View":        "allow",
+		"Administer":  "allow",
+		"Create":      "allow",
+		"ViewSecrets": "notset",
+		"Use":         "allow",
+		"Owner":       "allow",
+	})
+	config2 := hclVariableGroupPermissions(projectName, variableGroupName, map[string]string{
+		"View":        "allow",
+		"Administer":  "notset",
+		"Create":      "notset",
+		"ViewSecrets": "notset",
+		"Use":         "notset",
+		"Owner":       "notset",
+	})
+	tfNode := "azuredevops_variable_group_permissions.permissions"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.GetProviders(),
+		CheckDestroy: testutils.CheckProjectDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: config1,
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckProjectExists(projectName),
+					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfNode, "principal"),
+					resource.TestCheckResourceAttrSet(tfNode, "variable_group_id"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.%", "6"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.View", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Administer", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Create", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.ViewSecrets", "notset"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Use", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Owner", "allow"),
+				),
+			},
+			{
+				Config: config2,
+				Check: resource.ComposeTestCheckFunc(
+					testutils.CheckProjectExists(projectName),
+					resource.TestCheckResourceAttrSet(tfNode, "project_id"),
+					resource.TestCheckResourceAttrSet(tfNode, "principal"),
+					resource.TestCheckResourceAttrSet(tfNode, "variable_group_id"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.%", "6"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.View", "allow"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Administer", "notset"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Create", "notset"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.ViewSecrets", "notset"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Use", "notset"),
+					resource.TestCheckResourceAttr(tfNode, "permissions.Owner", "notset"),
+				),
+			},
+		},
+	})
+}

--- a/azuredevops/internal/service/permissions/resource_library_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_library_permissions.go
@@ -1,0 +1,91 @@
+package permissions
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	securityhelper "github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/permissions/utils"
+)
+
+// ResourceLibraryPermissions schema and implementation for variable group permission resource
+func ResourceLibraryPermissions() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLibraryPermissionsCreateOrUpdate,
+		Read:   resourceLibraryPermissionsRead,
+		Update: resourceLibraryPermissionsCreateOrUpdate,
+		Delete: resourceLibraryPermissionsDelete,
+		Schema: securityhelper.CreatePermissionResourceSchema(map[string]*schema.Schema{
+			"project_id": {
+				Type:         schema.TypeString,
+				ValidateFunc: validation.IsUUID,
+				Required:     true,
+				ForceNew:     true,
+			},
+		}),
+	}
+}
+
+func resourceLibraryPermissionsCreateOrUpdate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	sn, err := securityhelper.NewSecurityNamespace(d, clients, securityhelper.SecurityNamespaceIDValues.Library, createLibraryToken)
+	if err != nil {
+		return err
+	}
+
+	if err := securityhelper.SetPrincipalPermissions(d, sn, nil, false); err != nil {
+		return err
+	}
+
+	return resourceLibraryPermissionsRead(d, m)
+}
+
+func resourceLibraryPermissionsRead(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	sn, err := securityhelper.NewSecurityNamespace(d, clients, securityhelper.SecurityNamespaceIDValues.Library, createLibraryToken)
+	if err != nil {
+		return err
+	}
+
+	principalPermissions, err := securityhelper.GetPrincipalPermissions(d, sn)
+	if err != nil {
+		return err
+	}
+	if principalPermissions == nil {
+		d.SetId("")
+		log.Printf("[INFO] Permissions for ACL token %q not found. Removing from state", sn.GetToken())
+		return nil
+	}
+
+	d.Set("permissions", principalPermissions.Permissions)
+	return nil
+}
+
+func resourceLibraryPermissionsDelete(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	sn, err := securityhelper.NewSecurityNamespace(d, clients, securityhelper.SecurityNamespaceIDValues.Library, createLibraryToken)
+	if err != nil {
+		return err
+	}
+
+	if err := securityhelper.SetPrincipalPermissions(d, sn, &securityhelper.PermissionTypeValues.NotSet, true); err != nil {
+		return err
+	}
+	d.SetId("")
+	return nil
+}
+
+func createLibraryToken(d *schema.ResourceData, clients *client.AggregatedClient) (string, error) {
+	projectID, ok := d.GetOk("project_id")
+	if !ok {
+		return "", fmt.Errorf("Failed to get 'project_id' from schema")
+	}
+
+	aclToken := fmt.Sprintf("Library/%s", projectID.(string))
+	return aclToken, nil
+}

--- a/azuredevops/internal/service/permissions/resource_library_permissions_test.go
+++ b/azuredevops/internal/service/permissions/resource_library_permissions_test.go
@@ -1,0 +1,47 @@
+//go:build (all || permissions || resource_secure_file_permissions) && (!exclude_permissions || !resource_secure_file_permissions)
+// +build all permissions resource_secure_file_permissions
+// +build !exclude_permissions !resource_secure_file_permissions
+
+package permissions
+
+// The tests in this file use the mock clients in mock_client.go to mock out
+// the Azure DevOps client operations.
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+/**
+ * Begin unit tests
+ */
+
+var libraryToken = fmt.Sprintf("Library/%s", projectID)
+
+func TestLibraryPermissions_CreateLibraryToken(t *testing.T) {
+	var d *schema.ResourceData
+	var token string
+	var err error
+
+	d = getLibraryPermissionsResource(t, projectID)
+	token, err = createLibraryToken(d, nil)
+	assert.NotEmpty(t, token)
+	assert.Nil(t, err)
+	assert.Equal(t, libraryToken, token)
+
+	d = getLibraryPermissionsResource(t, "")
+	token, err = createLibraryToken(d, nil)
+	assert.Empty(t, token)
+	assert.NotNil(t, err)
+}
+
+func getLibraryPermissionsResource(t *testing.T, projectID string) *schema.ResourceData {
+	d := schema.TestResourceDataRaw(t, ResourceLibraryPermissions().Schema, nil)
+	if projectID != "" {
+		d.Set("project_id", projectID)
+	}
+	return d
+}

--- a/azuredevops/internal/service/permissions/resource_variable_group_permissions.go
+++ b/azuredevops/internal/service/permissions/resource_variable_group_permissions.go
@@ -1,0 +1,99 @@
+package permissions
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/client"
+	securityhelper "github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/service/permissions/utils"
+)
+
+// ResourceVariableGroupPermissions schema and implementation for variable group permission resource
+func ResourceVariableGroupPermissions() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVariableGroupPermissionsCreateOrUpdate,
+		Read:   resourceVariableGroupPermissionsRead,
+		Update: resourceVariableGroupPermissionsCreateOrUpdate,
+		Delete: resourceVariableGroupPermissionsDelete,
+		Schema: securityhelper.CreatePermissionResourceSchema(map[string]*schema.Schema{
+			"project_id": {
+				Type:         schema.TypeString,
+				ValidateFunc: validation.IsUUID,
+				Required:     true,
+				ForceNew:     true,
+			},
+			"variable_group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		}),
+	}
+}
+
+func resourceVariableGroupPermissionsCreateOrUpdate(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	sn, err := securityhelper.NewSecurityNamespace(d, clients, securityhelper.SecurityNamespaceIDValues.Library, createVariableGroupToken)
+	if err != nil {
+		return err
+	}
+
+	if err := securityhelper.SetPrincipalPermissions(d, sn, nil, false); err != nil {
+		return err
+	}
+
+	return resourceVariableGroupPermissionsRead(d, m)
+}
+
+func resourceVariableGroupPermissionsRead(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	sn, err := securityhelper.NewSecurityNamespace(d, clients, securityhelper.SecurityNamespaceIDValues.Library, createVariableGroupToken)
+	if err != nil {
+		return err
+	}
+
+	principalPermissions, err := securityhelper.GetPrincipalPermissions(d, sn)
+	if err != nil {
+		return err
+	}
+	if principalPermissions == nil {
+		d.SetId("")
+		log.Printf("[INFO] Permissions for ACL token %q not found. Removing from state", sn.GetToken())
+		return nil
+	}
+
+	d.Set("permissions", principalPermissions.Permissions)
+	return nil
+}
+
+func resourceVariableGroupPermissionsDelete(d *schema.ResourceData, m interface{}) error {
+	clients := m.(*client.AggregatedClient)
+
+	sn, err := securityhelper.NewSecurityNamespace(d, clients, securityhelper.SecurityNamespaceIDValues.Library, createVariableGroupToken)
+	if err != nil {
+		return err
+	}
+
+	if err := securityhelper.SetPrincipalPermissions(d, sn, &securityhelper.PermissionTypeValues.NotSet, true); err != nil {
+		return err
+	}
+	d.SetId("")
+	return nil
+}
+
+func createVariableGroupToken(d *schema.ResourceData, clients *client.AggregatedClient) (string, error) {
+	projectID, ok := d.GetOk("project_id")
+	if !ok {
+		return "", fmt.Errorf("Failed to get 'project_id' from schema")
+	}
+	variableGroupID, ok := d.GetOk("variable_group_id")
+	if !ok {
+		return "", fmt.Errorf("Failed to get 'variable_group_id' from schema")
+	}
+	aclToken := fmt.Sprintf("Library/%s/VariableGroup/%s", projectID.(string), variableGroupID.(string))
+	return aclToken, nil
+}

--- a/azuredevops/internal/service/permissions/resource_variable_group_permissions_test.go
+++ b/azuredevops/internal/service/permissions/resource_variable_group_permissions_test.go
@@ -1,0 +1,51 @@
+//go:build (all || permissions || resource_variable_group_permissions) && (!exclude_permissions || !resource_variable_group_permissions)
+// +build all permissions resource_variable_group_permissions
+// +build !exclude_permissions !resource_variable_group_permissions
+
+package permissions
+
+// The tests in this file use the mock clients in mock_client.go to mock out
+// the Azure DevOps client operations.
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+/**
+ * Begin unit tests
+ */
+
+var variableGroupID = "5"
+var variableGroupToken = fmt.Sprintf("Library/%s/VariableGroup/%s", projectID, variableGroupID)
+
+func TestVariableGroupsPermissions_CreateVariableGroupToken(t *testing.T) {
+	var d *schema.ResourceData
+	var token string
+	var err error
+
+	d = getVariableGroupPermissionsResource(t, projectID, variableGroupID)
+	token, err = createVariableGroupToken(d, nil)
+	assert.NotEmpty(t, token)
+	assert.Nil(t, err)
+	assert.Equal(t, variableGroupToken, token)
+
+	d = getVariableGroupPermissionsResource(t, "", "")
+	token, err = createVariableGroupToken(d, nil)
+	assert.Empty(t, token)
+	assert.NotNil(t, err)
+}
+
+func getVariableGroupPermissionsResource(t *testing.T, projectID string, variableGroupID string) *schema.ResourceData {
+	d := schema.TestResourceDataRaw(t, ResourceVariableGroupPermissions().Schema, nil)
+	if projectID != "" {
+		d.Set("project_id", projectID)
+	}
+	if variableGroupID != "" {
+		d.Set("variable_group_id", variableGroupID)
+	}
+	return d
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -34,6 +34,7 @@ func Provider() *schema.Provider {
 			"azuredevops_branch_policy_status_check":             branch.ResourceBranchPolicyStatusCheck(),
 			"azuredevops_build_definition":                       build.ResourceBuildDefinition(),
 			"azuredevops_build_folder":                           build.ResourceBuildFolder(),
+			"azuredevops_library_permissions":                    permissions.ResourceLibraryPermissions(),
 			"azuredevops_project":                                core.ResourceProject(),
 			"azuredevops_project_features":                       core.ResourceProjectFeatures(),
 			"azuredevops_project_pipeline_settings":              core.ResourceProjectPipelineSettings(),
@@ -91,6 +92,7 @@ func Provider() *schema.Provider {
 			"azuredevops_serviceendpoint_permissions":            permissions.ResourceServiceEndpointPermissions(),
 			"azuredevops_servicehook_permissions":                permissions.ResourceServiceHookPermissions(),
 			"azuredevops_tagging_permissions":                    permissions.ResourceTaggingPermissions(),
+			"azuredevops_variable_group_permissions":             permissions.ResourceVariableGroupPermissions(),
 			"azuredevops_environment":                            taskagent.ResourceEnvironment(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -19,6 +19,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_branch_policy_comment_resolution",
 		"azuredevops_branch_policy_merge_types",
 		"azuredevops_branch_policy_status_check",
+		"azuredevops_library_permissions",
 		"azuredevops_project",
 		"azuredevops_project_features",
 		"azuredevops_project_pipeline_settings",
@@ -77,6 +78,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_environment",
 		"azuredevops_build_folder",
 		"azuredevops_build_folder_permissions",
+		"azuredevops_variable_group_permissions",
 	}
 
 	resources := Provider().ResourcesMap

--- a/website/azuredevops.erb
+++ b/website/azuredevops.erb
@@ -152,6 +152,9 @@
                   <a href="/docs/providers/azuredevops/r/iteration_permissions.html">azuredevops_iteration_permissions</a>
                 </li>
                 <li>
+                  <a href="/docs/providers/azuredevops/r/library_permissions.html">azuredevops_library_permissions</a>
+                </li>
+                <li>
                   <a href="/docs/providers/azuredevops/r/project.html">azuredevops_project</a>
                 </li>
                 <li>
@@ -282,6 +285,9 @@
                 </li>
                 <li>
                   <a href="/docs/providers/azuredevops/r/variable_group.html">azuredevops_variable_group</a>
+                </li>
+                <li>
+                  <a href="/docs/providers/azuredevops/r/variable_group_permissions.html">azuredevops_variable_group_permissions</a>
                 </li>
                 <li>
                   <a href="/docs/providers/azuredevops/r/workitemquery_permissions.html">azuredevops_workitemquery_permissions</a>

--- a/website/docs/r/library_permissions.html.markdown
+++ b/website/docs/r/library_permissions.html.markdown
@@ -1,0 +1,79 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_library_permissions"
+description: |-
+  Manages permissions for a AzureDevOps Library
+---
+
+# azuredevops_library_permissions
+
+Manages permissions for a Library
+
+## Example Usage
+
+```hcl
+resource "azuredevops_project" "project" {
+  name               = "Testing"
+  description        = "Testing-description"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+}
+
+data "azuredevops_group" "tf-project-readers" {
+  project_id = azuredevops_project.project.id
+  name       = "Readers"
+}
+
+resource "azuredevops_library_permissions" "permissions" {
+  project_id        = azuredevops_project.project.id
+  principal         = data.azuredevops_group.tf-project-readers.id
+  permissions = {
+    "View" : "allow",
+    "Administer" : "allow",
+    "Use" : "allow",
+  }
+}
+```
+
+## Roles
+
+The Azure DevOps UI uses roles to assign permissions for the Library.
+
+| Role          | Allowed Permissions    |
+| ------------- | ---------------------- |
+| Reader        | View                   |
+| Creator       | View, Create           |
+| User          | View, Use              |
+| Administrator | View, Use, Administer  |
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) The ID of the project.
+* `principal` - (Required) The **group** principal to assign the permissions.
+* `permissions` - (Required) the permissions to assign. The following permissions are available.
+* `variable_group_id` - (Required) The id of the variable group to assign the permissions.
+* `replace` - (Optional) Replace (`true`) or merge (`false`) the permissions. Default: `true`
+
+| Permission        | Description                         |
+| ----------------- | ----------------------------------- |
+| View              | View library item                   |
+| Administer        | Administer library item             |
+| Create            | Create library item                 |
+| ViewSecrets       | View library item secrets           |
+| Use               | Use library item                    |
+| Owner             | Owner library item                  |
+
+## Relevant Links
+
+* [Azure DevOps Service REST API 6.0 - Security](https://docs.microsoft.com/en-us/rest/api/azure/devops/security/?view=azure-devops-rest-6.0)
+
+## Import
+
+The resource does not support import.
+
+## PAT Permissions Required
+
+- **Project & Team**: vso.security_manage - Grants the ability to read, write, and manage security permissions.

--- a/website/docs/r/variable_group_permissions.html.markdown
+++ b/website/docs/r/variable_group_permissions.html.markdown
@@ -1,0 +1,93 @@
+---
+layout: "azuredevops"
+page_title: "AzureDevops: azuredevops_variable_group_permissions"
+description: |-
+  Manages permissions for a AzureDevOps Variable Group
+---
+
+# azuredevops_variable_group_permissions
+
+Manages permissions for a Variable Group
+
+
+## Example Usage
+
+```hcl
+resource "azuredevops_project" "project" {
+  name               = "Testing"
+  description        = "Testing-description"
+  visibility         = "private"
+  version_control    = "Git"
+  work_item_template = "Agile"
+}
+
+resource "azuredevops_variable_group" "example" {
+  project_id   = azuredevops_project.project.id
+  name         = "test"
+  description  = "Test Description"
+  allow_access = true
+
+  variable {
+    name  = "key1"
+    value = "val1"
+  }
+}
+
+data "azuredevops_group" "tf-project-readers" {
+  project_id = azuredevops_project.project.id
+  name       = "Readers"
+}
+
+resource "azuredevops_variable_group_permissions" "permissions" {
+  project_id        = azuredevops_project.project.id
+  variable_group_id = azuredevops_variable_group.example.id
+  principal         = data.azuredevops_group.tf-project-readers.id
+  permissions = {
+    "View" : "allow",
+    "Administer" : "allow",
+    "Use" : "allow",
+  }
+}
+```
+
+## Roles
+
+The Azure DevOps UI uses roles to assign permissions for variable groups.
+
+| Role          | Allow Permissions      |
+| ------------- | ---------------------- |
+| Reader        | View                   |
+| User          | View, Use              |
+| Administrator | View, Use, Administer  |
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) The ID of the project.
+* `principal` - (Required) The **group** principal to assign the permissions.
+* `permissions` - (Required) the permissions to assign. The following permissions are available.
+* `variable_group_id` - (Required) The id of the variable group to assign the permissions.
+* `replace` - (Optional) Replace (`true`) or merge (`false`) the permissions. Default: `true`
+
+| Permission        | Description                         |
+| ----------------- | ----------------------------------- |
+| View              | View library item                   |
+| Administer        | Administer library item             |
+| Create            | Create library item                 |
+| ViewSecrets       | View library item secrets           |
+| Use               | Use library item                    |
+| Owner             | Owner library item                  |
+
+## Relevant Links
+
+* [Azure DevOps Service REST API 6.0 - Security](https://docs.microsoft.com/en-us/rest/api/azure/devops/security/?view=azure-devops-rest-6.0)
+
+## Import
+
+The resource does not support import.
+
+## PAT Permissions Required
+
+- **Project & Team**: vso.security_manage - Grants the ability to read, write, and manage security permissions.


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [ ] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

Adding resources `azuredevops_variable_group_permissions` and `azuredevops_library_permissions`.

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

I just started with the `azuredevops_serviceendpoint_permissions` resource and tests then revised them for the library and variable group.