### PR TITLE
Handle padded & unpadded base64 from Terraform tokens

### DIFF
--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -426,7 +426,11 @@ func GetAuthToken(ctx context.Context, d *schema.ResourceData, azIdentityFuncs A
 			if len(jwtParts) != 3 {
 				return "", errors.New("Unable to split TFC_WORKLOAD_IDENTITY_TOKEN jwt")
 			}
-			tokenClaims, err := base64.StdEncoding.DecodeString(jwtParts[1])
+			jwtClaims := jwtParts[1]
+			if i := len(jwtClaims) % 4; i != 0 {
+				jwtClaims += strings.Repeat("=", 4-i)
+			}
+			tokenClaims, err := base64.StdEncoding.DecodeString(jwtClaims)
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
Apparently the JWT from Terraform cloud has unpadded base64 data. Updated the code to fix any padding issues before parsing the token.