### PR TITLE
Fix missing protection status input for variable groups

### DIFF
--- a/azuredevops/internal/service/approvalsandchecks/resource_check_branch_control.go
+++ b/azuredevops/internal/service/approvalsandchecks/resource_check_branch_control.go
@@ -73,7 +73,8 @@ func flattenBranchControlCheck(d *schema.ResourceData, branchControlCheck *pipel
 			}
 			d.Set("ignore_unknown_protection_status", value)
 		} else {
-			return fmt.Errorf("allowUnknownStatusBranch input not found")
+			// Variable groups don't appear to support this property
+			d.Set("ignore_unknown_protection_status", false)
 		}
 	} else {
 		return fmt.Errorf("inputs not found")


### PR DESCRIPTION
Fixes #15. Apparently the protection status input isn't an option for Variable Groups. No clue why or why this just now started failing.